### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,6 +46,7 @@ Architecture: all
 Depends:
  ${sphinxdoc:Depends},
  ${misc:Depends},
+Multi-Arch: foreign
 Description: Blog-aware, static site generator (documentation)
  Blag is a blog-aware, static site generator, written in Python. It supports
  the following features:


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/blag/189739fc-277d-4405-884d-9c7a5628bf1f.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*blag\*\*
### Control files of package blag-doc: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/189739fc-277d-4405-884d-9c7a5628bf1f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/189739fc-277d-4405-884d-9c7a5628bf1f/diffoscope)).
