### PR TITLE
Don't use internal templates anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [unreleased]
+
+### Breaking
+
+* blag does not use default fallback templates anymore and will return an error
+  if it is unable to find required templates, e.g. in `templates/`.
+
+  Users upgrading from older versions can either run `blag quickstart` (don't
+  forget to backup your `config.ini` or copy the templates from blag's
+  resources (the resource path is shown in the error message).
+
+  New users are not affected as `blag quickstart` will generate the needed
+  templates.
+
+
 ## [1.5.0] - 2023-04-16
 
 * moved to pyproject.toml

--- a/blag/quickstart.py
+++ b/blag/quickstart.py
@@ -6,6 +6,10 @@
 from __future__ import annotations
 import configparser
 import argparse
+import shutil
+import os
+
+import blag
 
 
 def get_input(question: str, default: str) -> str:
@@ -31,6 +35,22 @@ def get_input(question: str, default: str) -> str:
     if not reply:
         reply = default
     return reply
+
+
+def copy_templates() -> None:
+    """Copy templates into current directory.
+
+    It will not overwrite existing files.
+
+    """
+    print("Copying templates...")
+    try:
+        shutil.copytree(
+            os.path.join(blag.__path__[0], 'templates'),
+            'templates',
+        )
+    except FileExistsError:
+        print("Templates already exist. Skipping.")
 
 
 def quickstart(args: argparse.Namespace | None) -> None:
@@ -71,3 +91,5 @@ def quickstart(args: argparse.Namespace | None) -> None:
     }
     with open('config.ini', 'w') as fh:
         config.write(fh)
+
+    copy_templates()

--- a/docs/blag.rst
+++ b/docs/blag.rst
@@ -13,7 +13,7 @@ Install blag from PyPI_
 
 .. _pypi: https://pypi.org/project/blag/
 
-Run blag's quickstart command to create the configuration needed
+Run blag's quickstart command to create the configuration and templates needed
 
 .. code-block:: sh
 
@@ -40,8 +40,8 @@ If you want more separation between the static files and the markdown content,
 you can put all static files into the ``static`` directory. Blag will copy
 them over to the ``build`` directory.
 
-If you want to customize the looks of the generated site, create a
-``template`` directory and put your jinja2 templates here.
+If you want to customize the look of the generated site, visit the ``template``
+directory. It contains jinja2 templates and can be modified as needed.
 
 Those directories can be changed via command line arguments. See
 
@@ -186,9 +186,7 @@ becomes
 Templating
 ----------
 
-Custom templates are **optional** and stored by default in the ``templates``
-directory. blag will search the ``templates`` directory first, and fall back
-to blag's default built-in templates.
+Templates are stored by default in the ``templates`` directory.
 
 ============ ====================================== ===================
 Template     Used For                               Variables

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,18 +8,18 @@ import os
 import pytest
 from jinja2 import Environment, Template
 
-from blag import blag
+from blag import blag, quickstart
 
 
 @pytest.fixture
-def environment() -> Iterator[Environment]:
+def environment(cleandir: str) -> Iterator[Environment]:
     site = {
         'base_url': 'site base_url',
         'title': 'site title',
         'description': 'site description',
         'author': 'site author',
     }
-    env = blag.environment_factory(globals_=dict(site=site))
+    env = blag.environment_factory('templates', globals_=dict(site=site))
     yield env
 
 
@@ -50,7 +50,7 @@ def tag_template(environment: Environment) -> Iterator[Template]:
 
 @pytest.fixture
 def cleandir() -> Iterator[str]:
-    """Create a temporary workind directory and cwd."""
+    """Create a temporary working directory and cwd."""
     config = """
 [main]
 base_url = https://example.com/
@@ -60,13 +60,14 @@ author = a. u. thor
     """
 
     with TemporaryDirectory() as dir:
-        for d in 'content', 'build', 'static', 'templates':
+        for d in 'content', 'build', 'static':
             os.mkdir(f'{dir}/{d}')
         with open(f'{dir}/config.ini', 'w') as fh:
             fh.write(config)
         # change directory
         old_cwd = os.getcwd()
         os.chdir(dir)
+        quickstart.copy_templates()
         yield dir
         # and change back afterwards
         os.chdir(old_cwd)

--- a/tests/test_blag.py
+++ b/tests/test_blag.py
@@ -179,9 +179,9 @@ author = a. u. thor
         assert config_parsed['base_url'] == 'https://example.com/'
 
 
-def test_environment_factory() -> None:
+def test_environment_factory(cleandir: str) -> None:
     globals_: dict[str, object] = {'foo': 'bar', 'test': 'me'}
-    env = blag.environment_factory(globals_=globals_)
+    env = blag.environment_factory("templates", globals_=globals_)
     assert env.globals['foo'] == 'bar'
     assert env.globals['test'] == 'me'
 
@@ -297,6 +297,22 @@ foo bar
     assert os.path.exists(f'{args.output_dir}/tags/index.html')
     assert os.path.exists(f'{args.output_dir}/tags/foo.html')
     assert os.path.exists(f'{args.output_dir}/tags/bar.html')
+
+
+@pytest.mark.parametrize(
+    'template',
+    [
+        'page.html',
+        'article.html',
+        'archive.html',
+        'tags.html',
+        'tag.html',
+    ]
+)
+def test_missing_template_raises(template: str, args: Namespace) -> None:
+    os.remove(f'templates/{template}')
+    with pytest.raises(SystemExit):
+        blag.build(args)
 
 
 def test_main(cleandir: str) -> None:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,5 +1,6 @@
 # remove when we don't support py38 anymore
 from __future__ import annotations
+import os
 
 from pytest import MonkeyPatch
 
@@ -27,3 +28,13 @@ def test_quickstart(cleandir: str, monkeypatch: MonkeyPatch) -> None:
     assert 'title = foo' in data
     assert 'description = foo' in data
     assert 'author = foo' in data
+
+    for template in (
+        "archive.html",
+        "article.html",
+        "base.html",
+        "page.html",
+        "tag.html",
+        "tags.html",
+    ):
+        assert os.path.exists(f'templates/{template}')


### PR DESCRIPTION
Blag will throw an error if a template is not found locally. The error message contains an explanation for the user on where to get the missing templates.

Quickstart will generate templates for the user in the working directory.

Updated tests appropriately.