### PR TITLE
Minor changes affecting Atom feed and Tag URLs

### DIFF
--- a/blag/blag.py
+++ b/blag/blag.py
@@ -396,7 +396,7 @@ def generate_feed(
         )
 
     with open(f"{output_dir}/atom.xml", "w") as fh:
-        feed.write(fh, encoding="utf8")
+        feed.write(fh, encoding="utf-8")
 
 
 def generate_index(

--- a/blag/markdown.py
+++ b/blag/markdown.py
@@ -51,6 +51,7 @@ def convert_markdown(
         * `date` is converted into datetime with local timezone
         * `tags` is interpreted as a comma-separeted list of strings.
           All strings are stripped and converted to lower case.
+          All strings have spaces replaced with dashes.
 
     Parameters
     ----------
@@ -85,6 +86,7 @@ def convert_markdown(
         tags = meta["tags"].split(",")
         tags = [t.lower() for t in tags]
         tags = [t.strip() for t in tags]
+        tags = [t.replace(" ","-") for t in tags]
         meta["tags"] = tags
 
     return content, meta


### PR DESCRIPTION
* changed atom encoding in blag.py to utf-8 in order to pass  https://validator.w3.org/feed/ feed validation
* changed markdown.py to replace space in tags with dash in order to avoid urls with spaces

Hi,

I'm really enjoying this software. I have two small suggestions. I am still very green when it comes to Python and website development, but I don't think these small changes break anything.