### PR TITLE
Add `permalink` and `source` to template vars in articles and pages

### DIFF
--- a/blag/blag.py
+++ b/blag/blag.py
@@ -330,7 +330,8 @@ def process_markdown(
 
         context = dict(
             content=content,
-            permalink=dst
+            permalink=dst,
+            source=src
         )
         context.update(meta)
 

--- a/blag/blag.py
+++ b/blag/blag.py
@@ -328,7 +328,10 @@ def process_markdown(
 
         content, meta = convert_markdown(md, body)
 
-        context = dict(content=content)
+        context = dict(
+            content=content,
+            permalink=dst
+        )
         context.update(meta)
 
         # if markdown has date in meta, we treat it as a blog article,


### PR DESCRIPTION
This patch adds `source` and `permalink` to template context for articles and pages

`source` is the relative source file parsed for the page
`permalink` is the relative destination html file path

(a repost of #306 , just from a new branch...)