### PR TITLE
add back and forth buttons to articles

### DIFF
--- a/blag/blag.py
+++ b/blag/blag.py
@@ -335,17 +335,39 @@ def process_markdown(
         # everything else are just pages
         if meta and "date" in meta:
             articles.append((dst, context))
-            result = article_template.render(context)
+            # articles will be rendered after sorting, 
+            # to add next&prev metadata
         else:
             pages.append((dst, context))
+            # we are can already render pages (no sorting needed)
             result = page_template.render(context)
-        with open(f"{output_dir}/{dst}", "w") as fh_dest:
-            fh_dest.write(result)
+            with open(f"{output_dir}/{dst}", "w") as fh_dest:
+                fh_dest.write(result)
 
     # sort articles by date, descending
     articles = sorted(articles, key=lambda x: x[1]["date"], reverse=True)
-    return articles, pages
 
+    # with the sorted list of articles
+    # add metadata for previous and next pages
+    for i in range(0,len(articles)):
+
+        if (i>0):
+            articles[i][1]["prv"]="/" + articles[i-1][0]
+        else:
+            articles[i][1]["prv"]="/"
+
+        if (i<(len(articles)-1)):
+            articles[i][1]["nxt"]="/" + articles[i+1][0]
+        else:
+            articles[i][1]["nxt"]="/"
+
+        # generate articles html files
+        result = article_template.render(articles[i][1])
+        dst=articles[i][0]
+        with open(f"{output_dir}/{dst}", "w") as fh_dest:
+            fh_dest.write(result)
+
+    return articles, pages
 
 def generate_feed(
     articles: list[tuple[str, dict[str, Any]]],

--- a/blag/templates/article.html
+++ b/blag/templates/article.html
@@ -4,6 +4,17 @@
 
 {% block content %}
 
+  {% if prv or nxt %}
+  <header><nav><ul>
+  {% if prv %}
+  <li><h2><a href="{{ prv }}">zurück</a><h2></li>
+  {% endif %}
+  {% if nxt %}
+  <li><h2><a href="{{ nxt }}">weiter</a><h2></li>
+  {% endif %}
+  </ul></nav></header>
+  {% endif %}
+
   {% if title %}
   <h2>{{ title }}</h2>
   {% endif %}
@@ -23,5 +34,16 @@
   </aside>
 
   {{ content }}
+
+  {% if prv or nxt %}
+  <header><nav><ul>
+  {% if prv %}
+  <li><h2><a href="{{ prv }}">zurück</a><h2></li>
+  {% endif %}
+  {% if nxt %}
+  <li><h2><a href="{{ nxt }}">weiter</a><h2></li>
+  {% endif %}
+  </ul></nav></header>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
I've added buttons for the previous and next article to my "blog" based on blag. I like to have them and I think this is a quite typical functionality.  

This probably does not satisfy your code style, so I do not think that this pull request will get accepted. Yet it is just to show that this functionality is possible and to trigger you to maybe implement it "in your style"?